### PR TITLE
Phase 1: characterization tests

### DIFF
--- a/src/utils/__tests__/__snapshots__/layout-generator.test.ts.snap
+++ b/src/utils/__tests__/__snapshots__/layout-generator.test.ts.snap
@@ -1,0 +1,293 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`generateCTAButtons snapshots foodlog CTA 1`] = `"<div class="nutrition-add-cta-container"><button id="nutrition-add-cta-test-0" class="nutrition-add-cta-btn" data-context="foodlog">➕ Add More Items to Food Log</button></div>"`;
+
+exports[`generateCTAButtons snapshots meal CTA includes data-meal-id 1`] = `"<div class="nutrition-add-cta-container"><button id="nutrition-add-cta-test-0" class="nutrition-add-cta-btn" data-context="meal" data-meal-id="meal-123">➕ Add More Items to Meal</button></div>"`;
+
+exports[`generateCardLayout snapshots (deterministic idGenerator injected) empty item list still renders the CTA button when a context is given 1`] = `"<div class="nutrition-add-cta-container"><button id="nutrition-add-cta-test-0" class="nutrition-add-cta-btn" data-context="foodlog">➕ Add More Items to Food Log</button></div>"`;
+
+exports[`generateCardLayout snapshots (deterministic idGenerator injected) foodlog context 1`] = `
+"
+<div id="ntr-test-0" class="ntr-food-card" data-ntr-food="Grilled chicken" data-ntr-quantity="150g" data-ntr-calories="250" data-ntr-protein="40" data-ntr-carbs="0" data-ntr-fat="8">
+  <div class="ntr-food-card-header">
+    <div class="ntr-food-card-info">
+      <span class="ntr-food-card-emoji">🍽️</span>
+      <div class="ntr-food-card-text">
+        <h3 class="ntr-food-card-title">Grilled chicken</h3>
+        <div class="ntr-food-card-quantity">📏 150g</div>
+      </div>
+    </div>
+    <div class="ntr-food-card-actions">
+      <button class="nutrition-edit-btn ntr-edit-btn" data-ntr-food="Grilled chicken" data-ntr-quantity="150g" data-ntr-calories="250" data-ntr-protein="40" data-ntr-carbs="0" data-ntr-fat="8" data-ntr-edit-context="foodlog">✏️ Edit</button>
+      <button class="nutrition-delete-btn ntr-delete-btn" data-ntr-food="Grilled chicken" data-ntr-quantity="150g" data-ntr-calories="250" data-ntr-protein="40" data-ntr-carbs="0" data-ntr-fat="8" data-ntr-edit-context="foodlog" data-ntr-entry-id="ntr-test-0">🗑️ Delete</button>
+    </div>
+  </div>
+  <div class="ntr-stats-grid">
+    <div class="ntr-stat-card ntr-stat-card-calories">
+      <div class="ntr-stat-emoji ntr-stat-emoji-calories"></div>
+      <div class="ntr-stat-value">250</div>
+      <div class="ntr-stat-label">kcal</div>
+    </div>
+    <div class="ntr-stat-card ntr-stat-card-protein">
+      <div class="ntr-stat-emoji ntr-stat-emoji-protein"></div>
+      <div class="ntr-stat-value">40g</div>
+      <div class="ntr-stat-label">protein</div>
+    </div>
+    <div class="ntr-stat-card ntr-stat-card-carbs">
+      <div class="ntr-stat-emoji ntr-stat-emoji-carbs"></div>
+      <div class="ntr-stat-value">0g</div>
+      <div class="ntr-stat-label">carbs</div>
+    </div>
+    <div class="ntr-stat-card ntr-stat-card-fat">
+      <div class="ntr-stat-emoji ntr-stat-emoji-fat"></div>
+      <div class="ntr-stat-value">8g</div>
+      <div class="ntr-stat-label">fat</div>
+    </div>
+  </div>
+</div>
+
+
+<div id="ntr-test-1" class="ntr-food-card" data-ntr-food="Brown rice" data-ntr-quantity="100g" data-ntr-calories="130" data-ntr-protein="3" data-ntr-carbs="28" data-ntr-fat="1">
+  <div class="ntr-food-card-header">
+    <div class="ntr-food-card-info">
+      <span class="ntr-food-card-emoji">🍽️</span>
+      <div class="ntr-food-card-text">
+        <h3 class="ntr-food-card-title">Brown rice</h3>
+        <div class="ntr-food-card-quantity">📏 100g</div>
+      </div>
+    </div>
+    <div class="ntr-food-card-actions">
+      <button class="nutrition-edit-btn ntr-edit-btn" data-ntr-food="Brown rice" data-ntr-quantity="100g" data-ntr-calories="130" data-ntr-protein="3" data-ntr-carbs="28" data-ntr-fat="1" data-ntr-edit-context="foodlog">✏️ Edit</button>
+      <button class="nutrition-delete-btn ntr-delete-btn" data-ntr-food="Brown rice" data-ntr-quantity="100g" data-ntr-calories="130" data-ntr-protein="3" data-ntr-carbs="28" data-ntr-fat="1" data-ntr-edit-context="foodlog" data-ntr-entry-id="ntr-test-1">🗑️ Delete</button>
+    </div>
+  </div>
+  <div class="ntr-stats-grid">
+    <div class="ntr-stat-card ntr-stat-card-calories">
+      <div class="ntr-stat-emoji ntr-stat-emoji-calories"></div>
+      <div class="ntr-stat-value">130</div>
+      <div class="ntr-stat-label">kcal</div>
+    </div>
+    <div class="ntr-stat-card ntr-stat-card-protein">
+      <div class="ntr-stat-emoji ntr-stat-emoji-protein"></div>
+      <div class="ntr-stat-value">3g</div>
+      <div class="ntr-stat-label">protein</div>
+    </div>
+    <div class="ntr-stat-card ntr-stat-card-carbs">
+      <div class="ntr-stat-emoji ntr-stat-emoji-carbs"></div>
+      <div class="ntr-stat-value">28g</div>
+      <div class="ntr-stat-label">carbs</div>
+    </div>
+    <div class="ntr-stat-card ntr-stat-card-fat">
+      <div class="ntr-stat-emoji ntr-stat-emoji-fat"></div>
+      <div class="ntr-stat-value">1g</div>
+      <div class="ntr-stat-label">fat</div>
+    </div>
+  </div>
+</div>
+
+<div class="nutrition-add-cta-container"><button id="nutrition-add-cta-test-2" class="nutrition-add-cta-btn" data-context="foodlog">➕ Add More Items to Food Log</button></div>"
+`;
+
+exports[`generateCardLayout snapshots (deterministic idGenerator injected) meal context includes the meal add-to-meal CTA and meal id 1`] = `
+"
+<div id="ntr-test-0" class="ntr-food-card" data-ntr-food="Grilled chicken" data-ntr-quantity="150g" data-ntr-calories="250" data-ntr-protein="40" data-ntr-carbs="0" data-ntr-fat="8">
+  <div class="ntr-food-card-header">
+    <div class="ntr-food-card-info">
+      <span class="ntr-food-card-emoji">🍽️</span>
+      <div class="ntr-food-card-text">
+        <h3 class="ntr-food-card-title">Grilled chicken</h3>
+        <div class="ntr-food-card-quantity">📏 150g</div>
+      </div>
+    </div>
+    <div class="ntr-food-card-actions">
+      <button class="nutrition-edit-btn ntr-edit-btn" data-ntr-food="Grilled chicken" data-ntr-quantity="150g" data-ntr-calories="250" data-ntr-protein="40" data-ntr-carbs="0" data-ntr-fat="8" data-ntr-edit-context="meal">✏️ Edit</button>
+      <button class="nutrition-delete-btn ntr-delete-btn" data-ntr-food="Grilled chicken" data-ntr-quantity="150g" data-ntr-calories="250" data-ntr-protein="40" data-ntr-carbs="0" data-ntr-fat="8" data-ntr-edit-context="meal" data-ntr-entry-id="ntr-test-0">🗑️ Delete</button>
+    </div>
+  </div>
+  <div class="ntr-stats-grid">
+    <div class="ntr-stat-card ntr-stat-card-calories">
+      <div class="ntr-stat-emoji ntr-stat-emoji-calories"></div>
+      <div class="ntr-stat-value">250</div>
+      <div class="ntr-stat-label">kcal</div>
+    </div>
+    <div class="ntr-stat-card ntr-stat-card-protein">
+      <div class="ntr-stat-emoji ntr-stat-emoji-protein"></div>
+      <div class="ntr-stat-value">40g</div>
+      <div class="ntr-stat-label">protein</div>
+    </div>
+    <div class="ntr-stat-card ntr-stat-card-carbs">
+      <div class="ntr-stat-emoji ntr-stat-emoji-carbs"></div>
+      <div class="ntr-stat-value">0g</div>
+      <div class="ntr-stat-label">carbs</div>
+    </div>
+    <div class="ntr-stat-card ntr-stat-card-fat">
+      <div class="ntr-stat-emoji ntr-stat-emoji-fat"></div>
+      <div class="ntr-stat-value">8g</div>
+      <div class="ntr-stat-label">fat</div>
+    </div>
+  </div>
+</div>
+
+
+<div id="ntr-test-1" class="ntr-food-card" data-ntr-food="Brown rice" data-ntr-quantity="100g" data-ntr-calories="130" data-ntr-protein="3" data-ntr-carbs="28" data-ntr-fat="1">
+  <div class="ntr-food-card-header">
+    <div class="ntr-food-card-info">
+      <span class="ntr-food-card-emoji">🍽️</span>
+      <div class="ntr-food-card-text">
+        <h3 class="ntr-food-card-title">Brown rice</h3>
+        <div class="ntr-food-card-quantity">📏 100g</div>
+      </div>
+    </div>
+    <div class="ntr-food-card-actions">
+      <button class="nutrition-edit-btn ntr-edit-btn" data-ntr-food="Brown rice" data-ntr-quantity="100g" data-ntr-calories="130" data-ntr-protein="3" data-ntr-carbs="28" data-ntr-fat="1" data-ntr-edit-context="meal">✏️ Edit</button>
+      <button class="nutrition-delete-btn ntr-delete-btn" data-ntr-food="Brown rice" data-ntr-quantity="100g" data-ntr-calories="130" data-ntr-protein="3" data-ntr-carbs="28" data-ntr-fat="1" data-ntr-edit-context="meal" data-ntr-entry-id="ntr-test-1">🗑️ Delete</button>
+    </div>
+  </div>
+  <div class="ntr-stats-grid">
+    <div class="ntr-stat-card ntr-stat-card-calories">
+      <div class="ntr-stat-emoji ntr-stat-emoji-calories"></div>
+      <div class="ntr-stat-value">130</div>
+      <div class="ntr-stat-label">kcal</div>
+    </div>
+    <div class="ntr-stat-card ntr-stat-card-protein">
+      <div class="ntr-stat-emoji ntr-stat-emoji-protein"></div>
+      <div class="ntr-stat-value">3g</div>
+      <div class="ntr-stat-label">protein</div>
+    </div>
+    <div class="ntr-stat-card ntr-stat-card-carbs">
+      <div class="ntr-stat-emoji ntr-stat-emoji-carbs"></div>
+      <div class="ntr-stat-value">28g</div>
+      <div class="ntr-stat-label">carbs</div>
+    </div>
+    <div class="ntr-stat-card ntr-stat-card-fat">
+      <div class="ntr-stat-emoji ntr-stat-emoji-fat"></div>
+      <div class="ntr-stat-value">1g</div>
+      <div class="ntr-stat-label">fat</div>
+    </div>
+  </div>
+</div>
+
+<div class="nutrition-add-cta-container"><button id="nutrition-add-cta-test-2" class="nutrition-add-cta-btn" data-context="meal" data-meal-id="meal-123">➕ Add More Items to Meal</button></div>"
+`;
+
+exports[`generateCardLayout snapshots (deterministic idGenerator injected) no context renders cards without CTA buttons 1`] = `
+"
+<div id="ntr-test-0" class="ntr-food-card" data-ntr-food="Grilled chicken" data-ntr-quantity="150g" data-ntr-calories="250" data-ntr-protein="40" data-ntr-carbs="0" data-ntr-fat="8">
+  <div class="ntr-food-card-header">
+    <div class="ntr-food-card-info">
+      <span class="ntr-food-card-emoji">🍽️</span>
+      <div class="ntr-food-card-text">
+        <h3 class="ntr-food-card-title">Grilled chicken</h3>
+        <div class="ntr-food-card-quantity">📏 150g</div>
+      </div>
+    </div>
+    <div class="ntr-food-card-actions">
+      <button class="nutrition-edit-btn ntr-edit-btn" data-ntr-food="Grilled chicken" data-ntr-quantity="150g" data-ntr-calories="250" data-ntr-protein="40" data-ntr-carbs="0" data-ntr-fat="8" data-ntr-edit-context="foodlog">✏️ Edit</button>
+      <button class="nutrition-delete-btn ntr-delete-btn" data-ntr-food="Grilled chicken" data-ntr-quantity="150g" data-ntr-calories="250" data-ntr-protein="40" data-ntr-carbs="0" data-ntr-fat="8" data-ntr-edit-context="foodlog" data-ntr-entry-id="ntr-test-0">🗑️ Delete</button>
+    </div>
+  </div>
+  <div class="ntr-stats-grid">
+    <div class="ntr-stat-card ntr-stat-card-calories">
+      <div class="ntr-stat-emoji ntr-stat-emoji-calories"></div>
+      <div class="ntr-stat-value">250</div>
+      <div class="ntr-stat-label">kcal</div>
+    </div>
+    <div class="ntr-stat-card ntr-stat-card-protein">
+      <div class="ntr-stat-emoji ntr-stat-emoji-protein"></div>
+      <div class="ntr-stat-value">40g</div>
+      <div class="ntr-stat-label">protein</div>
+    </div>
+    <div class="ntr-stat-card ntr-stat-card-carbs">
+      <div class="ntr-stat-emoji ntr-stat-emoji-carbs"></div>
+      <div class="ntr-stat-value">0g</div>
+      <div class="ntr-stat-label">carbs</div>
+    </div>
+    <div class="ntr-stat-card ntr-stat-card-fat">
+      <div class="ntr-stat-emoji ntr-stat-emoji-fat"></div>
+      <div class="ntr-stat-value">8g</div>
+      <div class="ntr-stat-label">fat</div>
+    </div>
+  </div>
+</div>
+
+
+<div id="ntr-test-1" class="ntr-food-card" data-ntr-food="Brown rice" data-ntr-quantity="100g" data-ntr-calories="130" data-ntr-protein="3" data-ntr-carbs="28" data-ntr-fat="1">
+  <div class="ntr-food-card-header">
+    <div class="ntr-food-card-info">
+      <span class="ntr-food-card-emoji">🍽️</span>
+      <div class="ntr-food-card-text">
+        <h3 class="ntr-food-card-title">Brown rice</h3>
+        <div class="ntr-food-card-quantity">📏 100g</div>
+      </div>
+    </div>
+    <div class="ntr-food-card-actions">
+      <button class="nutrition-edit-btn ntr-edit-btn" data-ntr-food="Brown rice" data-ntr-quantity="100g" data-ntr-calories="130" data-ntr-protein="3" data-ntr-carbs="28" data-ntr-fat="1" data-ntr-edit-context="foodlog">✏️ Edit</button>
+      <button class="nutrition-delete-btn ntr-delete-btn" data-ntr-food="Brown rice" data-ntr-quantity="100g" data-ntr-calories="130" data-ntr-protein="3" data-ntr-carbs="28" data-ntr-fat="1" data-ntr-edit-context="foodlog" data-ntr-entry-id="ntr-test-1">🗑️ Delete</button>
+    </div>
+  </div>
+  <div class="ntr-stats-grid">
+    <div class="ntr-stat-card ntr-stat-card-calories">
+      <div class="ntr-stat-emoji ntr-stat-emoji-calories"></div>
+      <div class="ntr-stat-value">130</div>
+      <div class="ntr-stat-label">kcal</div>
+    </div>
+    <div class="ntr-stat-card ntr-stat-card-protein">
+      <div class="ntr-stat-emoji ntr-stat-emoji-protein"></div>
+      <div class="ntr-stat-value">3g</div>
+      <div class="ntr-stat-label">protein</div>
+    </div>
+    <div class="ntr-stat-card ntr-stat-card-carbs">
+      <div class="ntr-stat-emoji ntr-stat-emoji-carbs"></div>
+      <div class="ntr-stat-value">28g</div>
+      <div class="ntr-stat-label">carbs</div>
+    </div>
+    <div class="ntr-stat-card ntr-stat-card-fat">
+      <div class="ntr-stat-emoji ntr-stat-emoji-fat"></div>
+      <div class="ntr-stat-value">1g</div>
+      <div class="ntr-stat-label">fat</div>
+    </div>
+  </div>
+</div>
+
+"
+`;
+
+exports[`generateDailySummary / generateMealProgressSummaryWithId snapshots daily summary vs goals 1`] = `
+"<div class="ntr-summary-card">
+<h3 class="ntr-summary-title">🎯 Totals vs Goals</h3>
+<div class="ntr-summary-divider"></div>
+  <div class="ntr-progress-row" data-nutrient="calories"><span class="ntr-progress-label"><span class="ntr-progress-emoji-calories"></span> Calories:</span> <span class="ntr-progress-values">1500 / 2000 kcal</span> <span class="ntr-progress-percentage zone-light-green">(75%)</span><div class="ntr-progress-track"><div class="ntr-progress-fill zone-light-green" style="--progress-width: 75;"><div class="ntr-progress-shine"></div><div class="ntr-progress-glow"></div></div></div></div>
+  <div class="ntr-progress-row" data-nutrient="protein"><span class="ntr-progress-label"><span class="ntr-progress-emoji-protein"></span> Protein:</span> <span class="ntr-progress-values">100 / 150 g</span> <span class="ntr-progress-percentage zone-yellow">(67%)</span><div class="ntr-progress-track"><div class="ntr-progress-fill zone-yellow" style="--progress-width: 67;"><div class="ntr-progress-shine"></div><div class="ntr-progress-glow"></div></div></div></div>
+  <div class="ntr-progress-row" data-nutrient="carbs"><span class="ntr-progress-label"><span class="ntr-progress-emoji-carbs"></span> Carbs:</span> <span class="ntr-progress-values">90 / 100 g</span> <span class="ntr-progress-percentage zone-green">(90%)</span><div class="ntr-progress-track"><div class="ntr-progress-fill zone-green" style="--progress-width: 90;"><div class="ntr-progress-shine"></div><div class="ntr-progress-glow"></div></div></div></div>
+  <div class="ntr-progress-row" data-nutrient="fat"><span class="ntr-progress-label"><span class="ntr-progress-emoji-fat"></span> Fat:</span> <span class="ntr-progress-values">50 / 80 g</span> <span class="ntr-progress-percentage zone-yellow">(63%)</span><div class="ntr-progress-track"><div class="ntr-progress-fill zone-yellow" style="--progress-width: 63;"><div class="ntr-progress-shine"></div><div class="ntr-progress-glow"></div></div></div></div>
+<div class="ntr-overall-progress">
+<div class="ntr-overall-progress-border">
+<div class="ntr-overall-progress-inner">
+<h3 class="ntr-overall-progress-title">💪 Overall Progress: 74%</h3>
+</div></div></div></div>
+"
+`;
+
+exports[`generateDailySummary / generateMealProgressSummaryWithId snapshots goal of zero does not divide by zero in the progress bars 1`] = `
+"  <div class="ntr-progress-row" data-nutrient="calories"><span class="ntr-progress-label"><span class="ntr-progress-emoji-calories"></span> Calories:</span> <span class="ntr-progress-values">1500 / 0 kcal</span> <span class="ntr-progress-percentage zone-red">(0%)</span><div class="ntr-progress-track"><div class="ntr-progress-fill zone-red" style="--progress-width: 0;"></div></div></div>
+  <div class="ntr-progress-row" data-nutrient="protein"><span class="ntr-progress-label"><span class="ntr-progress-emoji-protein"></span> Protein:</span> <span class="ntr-progress-values">100 / 0 g</span> <span class="ntr-progress-percentage zone-red">(0%)</span><div class="ntr-progress-track"><div class="ntr-progress-fill zone-red" style="--progress-width: 0;"></div></div></div>
+  <div class="ntr-progress-row" data-nutrient="carbs"><span class="ntr-progress-label"><span class="ntr-progress-emoji-carbs"></span> Carbs:</span> <span class="ntr-progress-values">90 / 0 g</span> <span class="ntr-progress-percentage zone-red">(0%)</span><div class="ntr-progress-track"><div class="ntr-progress-fill zone-red" style="--progress-width: 0;"></div></div></div>
+  <div class="ntr-progress-row" data-nutrient="fat"><span class="ntr-progress-label"><span class="ntr-progress-emoji-fat"></span> Fat:</span> <span class="ntr-progress-values">50 / 0 g</span> <span class="ntr-progress-percentage zone-red">(0%)</span><div class="ntr-progress-track"><div class="ntr-progress-fill zone-red" style="--progress-width: 0;"></div></div></div>
+"
+`;
+
+exports[`generateDailySummary / generateMealProgressSummaryWithId snapshots meal summary vs goals includes the meal id 1`] = `
+"<div class="ntr-summary-card" data-meal-id="meal-123">
+<h3 class="ntr-summary-title">🎯 Meal vs Goals</h3>
+<div class="ntr-summary-divider"></div>
+  <div class="ntr-progress-row" data-nutrient="calories"><span class="ntr-progress-label"><span class="ntr-progress-emoji-calories"></span> Calories:</span> <span class="ntr-progress-values">1500 / 2000 kcal</span> <span class="ntr-progress-percentage zone-light-green">(75%)</span><div class="ntr-progress-track"><div class="ntr-progress-fill zone-light-green" style="--progress-width: 75;"><div class="ntr-progress-shine"></div><div class="ntr-progress-glow"></div></div></div></div>
+  <div class="ntr-progress-row" data-nutrient="protein"><span class="ntr-progress-label"><span class="ntr-progress-emoji-protein"></span> Protein:</span> <span class="ntr-progress-values">100 / 150 g</span> <span class="ntr-progress-percentage zone-yellow">(67%)</span><div class="ntr-progress-track"><div class="ntr-progress-fill zone-yellow" style="--progress-width: 67;"><div class="ntr-progress-shine"></div><div class="ntr-progress-glow"></div></div></div></div>
+  <div class="ntr-progress-row" data-nutrient="carbs"><span class="ntr-progress-label"><span class="ntr-progress-emoji-carbs"></span> Carbs:</span> <span class="ntr-progress-values">90 / 100 g</span> <span class="ntr-progress-percentage zone-green">(90%)</span><div class="ntr-progress-track"><div class="ntr-progress-fill zone-green" style="--progress-width: 90;"><div class="ntr-progress-shine"></div><div class="ntr-progress-glow"></div></div></div></div>
+  <div class="ntr-progress-row" data-nutrient="fat"><span class="ntr-progress-label"><span class="ntr-progress-emoji-fat"></span> Fat:</span> <span class="ntr-progress-values">50 / 80 g</span> <span class="ntr-progress-percentage zone-yellow">(63%)</span><div class="ntr-progress-track"><div class="ntr-progress-fill zone-yellow" style="--progress-width: 63;"><div class="ntr-progress-shine"></div><div class="ntr-progress-glow"></div></div></div></div>
+<div class="ntr-overall-progress">
+<div class="ntr-overall-progress-border">
+<div class="ntr-overall-progress-inner">
+<h3 class="ntr-overall-progress-title">💪 Overall Progress: 74%</h3>
+</div></div></div></div>
+"
+`;

--- a/src/utils/__tests__/content-parser.test.ts
+++ b/src/utils/__tests__/content-parser.test.ts
@@ -1,0 +1,122 @@
+import { generateCardLayout } from '../layout-generator';
+import {
+  extractFoodItemsFromContent,
+  calculateTotals,
+  calculatePercentage,
+  deleteCardFromContent,
+} from '../content-parser';
+import { FoodItem, NutritionGoals } from '../../types/nutrition';
+
+const goals: NutritionGoals = { calories: 2000, protein: 150, carbs: 100, fat: 80 };
+
+describe('extractFoodItemsFromContent — round trip against generateCardLayout output', () => {
+  test('plain food item', () => {
+    const item: FoodItem = { food: 'Chicken breast', quantity: '150g', calories: 250, protein: 40, carbs: 0, fat: 8 };
+    const content = generateCardLayout([item], goals);
+    expect(extractFoodItemsFromContent(content)).toEqual([item]);
+  });
+
+  test('multiple food items preserve order', () => {
+    const items: FoodItem[] = [
+      { food: 'Oats', quantity: '50g', calories: 190, protein: 7, carbs: 33, fat: 3 },
+      { food: 'Banana', quantity: '1 medium', calories: 105, protein: 1, carbs: 27, fat: 0 },
+    ];
+    const content = generateCardLayout(items, goals);
+    expect(extractFoodItemsFromContent(content)).toEqual(items);
+  });
+
+  test('double quotes in food name round trip through &quot; escaping', () => {
+    const item: FoodItem = { food: 'Rice "Basmati"', quantity: '100g', calories: 130, protein: 2.7, carbs: 28, fat: 0.3 };
+    const content = generateCardLayout([item], goals);
+    expect(content).toContain('data-ntr-food="Rice &quot;Basmati&quot;"');
+    expect(extractFoodItemsFromContent(content)).toEqual([item]);
+  });
+
+  test('regex-metacharacter-heavy food name round trips correctly (extraction does not build a regex from food data)', () => {
+    const item: FoodItem = { food: 'Chicken (grilled) + rice [200g]', quantity: '1 serving', calories: 300, protein: 30, carbs: 20, fat: 10 };
+    const content = generateCardLayout([item], goals);
+    expect(extractFoodItemsFromContent(content)).toEqual([item]);
+  });
+
+  test('unicode and emoji in food name round trip', () => {
+    const item: FoodItem = { food: 'Käsespätzle 🧀', quantity: '1 Portion', calories: 480, protein: 18, carbs: 55, fat: 20 };
+    const content = generateCardLayout([item], goals);
+    expect(extractFoodItemsFromContent(content)).toEqual([item]);
+  });
+
+  test('decimal macro values round trip', () => {
+    const item: FoodItem = { food: 'Almonds', quantity: '15g', calories: 87.3, protein: 3.2, carbs: 2.5, fat: 7.5 };
+    const content = generateCardLayout([item], goals);
+    expect(extractFoodItemsFromContent(content)).toEqual([item]);
+  });
+
+  test('zero-value macros round trip', () => {
+    const item: FoodItem = { food: 'Black coffee', quantity: '1 cup', calories: 0, protein: 0, carbs: 0, fat: 0 };
+    const content = generateCardLayout([item], goals);
+    expect(extractFoodItemsFromContent(content)).toEqual([item]);
+  });
+
+  test('no food cards in content returns an empty array', () => {
+    expect(extractFoodItemsFromContent('# Just a heading\n\nSome notes.')).toEqual([]);
+  });
+});
+
+describe('calculateTotals', () => {
+  test('sums calories, protein, carbs and fat across items', () => {
+    const items: FoodItem[] = [
+      { food: 'A', quantity: '1', calories: 100, protein: 10, carbs: 5, fat: 2 },
+      { food: 'B', quantity: '1', calories: 200, protein: 20, carbs: 15, fat: 8 },
+    ];
+    expect(calculateTotals(items)).toEqual({ calories: 300, protein: 30, carbs: 20, fat: 10 });
+  });
+
+  test('empty item list totals to zero', () => {
+    expect(calculateTotals([])).toEqual({ calories: 0, protein: 0, carbs: 0, fat: 0 });
+  });
+
+  test('treats missing/undefined macro fields as zero', () => {
+    const items = [{ food: 'A', quantity: '1' } as FoodItem];
+    expect(calculateTotals(items)).toEqual({ calories: 0, protein: 0, carbs: 0, fat: 0 });
+  });
+});
+
+describe('calculatePercentage', () => {
+  test('rounds to the nearest percent', () => {
+    expect(calculatePercentage(150, 200)).toBe(75);
+    expect(calculatePercentage(1, 3)).toBe(33);
+  });
+
+  test('goal of zero returns zero instead of dividing by zero', () => {
+    expect(calculatePercentage(100, 0)).toBe(0);
+    expect(calculatePercentage(0, 0)).toBe(0);
+  });
+
+  test('can exceed 100 when current exceeds goal', () => {
+    expect(calculatePercentage(300, 200)).toBe(150);
+  });
+});
+
+describe('documented bug: duplicate identical entries are indistinguishable to deleteCardFromContent', () => {
+  test('deleting one of two identical entries always removes the first one in document order, not necessarily the one the user targeted', () => {
+    const duplicate = { food: 'Egg', quantity: '2 pcs', calories: 140, protein: 12, carbs: 1, fat: 10 };
+    const first: FoodItem = { ...duplicate, timestamp: '2026-07-13T08:00:00.000Z' };
+    const second: FoodItem = { ...duplicate, timestamp: '2026-07-13T18:00:00.000Z' };
+    const content = generateCardLayout([first, second], goals);
+
+    // The identity used for lookup is the (food, quantity, calories, protein, carbs, fat) tuple —
+    // it carries no timestamp/id, so both cards match equally and only positional order decides
+    // which one is removed. There is no way to ask "delete the second Egg entry" specifically.
+    const result = deleteCardFromContent(content, duplicate);
+
+    expect(result.success).toBe(true);
+    const remainingCards = extractFoodItemsFromContent(result.content);
+    expect(remainingCards).toHaveLength(1);
+
+    // Always the first-in-document-order card is removed, regardless of which one a user
+    // clicked delete on in the rendered note — this is the ambiguity the refactor's stable
+    // per-entry IDs are meant to fix. Only the second (later) entry's timestamp survives.
+    const survivingTimestamps = result.content.match(/ntr-food-card-timestamp">🕐 [^<]+</g) ?? [];
+    expect(survivingTimestamps).toHaveLength(1);
+    expect(result.content).not.toContain(new Date(first.timestamp!).toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit' }));
+  });
+});

--- a/src/utils/__tests__/layout-generator.test.ts
+++ b/src/utils/__tests__/layout-generator.test.ts
@@ -1,0 +1,88 @@
+import {
+  generateCardLayout,
+  generateCTAButtons,
+  generateDailySummary,
+  generateMealProgressSummaryWithId,
+  generateModernProgressBars,
+  getColorZone,
+  IdGenerator,
+} from '../layout-generator';
+import { FoodItem, NutritionData, NutritionGoals } from '../../types/nutrition';
+
+function makeDeterministicIdGenerator(): IdGenerator {
+  let counter = 0;
+  return (prefix: string) => `${prefix}-test-${counter++}`;
+}
+
+const goals: NutritionGoals = { calories: 2000, protein: 150, carbs: 100, fat: 80 };
+
+const items: FoodItem[] = [
+  { food: 'Grilled chicken', quantity: '150g', calories: 250, protein: 40, carbs: 0, fat: 8 },
+  { food: 'Brown rice', quantity: '100g', calories: 130, protein: 3, carbs: 28, fat: 1 },
+];
+
+describe('generateCardLayout snapshots (deterministic idGenerator injected)', () => {
+  test('foodlog context', () => {
+    expect(generateCardLayout(items, goals, 'foodlog', undefined, makeDeterministicIdGenerator())).toMatchSnapshot();
+  });
+
+  test('meal context includes the meal add-to-meal CTA and meal id', () => {
+    expect(generateCardLayout(items, goals, 'meal', 'meal-123', makeDeterministicIdGenerator())).toMatchSnapshot();
+  });
+
+  test('no context renders cards without CTA buttons', () => {
+    expect(generateCardLayout(items, goals, undefined, undefined, makeDeterministicIdGenerator())).toMatchSnapshot();
+  });
+
+  test('empty item list with no context renders nothing', () => {
+    expect(generateCardLayout([], goals, undefined, undefined, makeDeterministicIdGenerator())).toBe('');
+  });
+
+  test('empty item list still renders the CTA button when a context is given', () => {
+    expect(generateCardLayout([], goals, 'foodlog', undefined, makeDeterministicIdGenerator())).toMatchSnapshot();
+  });
+});
+
+describe('generateCTAButtons snapshots', () => {
+  test('foodlog CTA', () => {
+    expect(generateCTAButtons('foodlog', undefined, makeDeterministicIdGenerator())).toMatchSnapshot();
+  });
+
+  test('meal CTA includes data-meal-id', () => {
+    expect(generateCTAButtons('meal', 'meal-123', makeDeterministicIdGenerator())).toMatchSnapshot();
+  });
+});
+
+describe('generateDailySummary / generateMealProgressSummaryWithId snapshots', () => {
+  const totals: NutritionData = { calories: 1500, protein: 100, carbs: 90, fat: 50 };
+
+  test('daily summary vs goals', () => {
+    expect(generateDailySummary(totals, goals)).toMatchSnapshot();
+  });
+
+  test('meal summary vs goals includes the meal id', () => {
+    expect(generateMealProgressSummaryWithId(totals, goals, 'meal-123')).toMatchSnapshot();
+  });
+
+  test('goal of zero does not divide by zero in the progress bars', () => {
+    const zeroGoals: NutritionGoals = { calories: 0, protein: 0, carbs: 0, fat: 0 };
+    expect(generateModernProgressBars(totals, zeroGoals)).toMatchSnapshot();
+  });
+});
+
+describe('getColorZone', () => {
+  test.each([
+    [0, 'zone-red'],
+    [24, 'zone-red'],
+    [25, 'zone-orange'],
+    [49, 'zone-orange'],
+    [50, 'zone-yellow'],
+    [74, 'zone-yellow'],
+    [75, 'zone-light-green'],
+    [89, 'zone-light-green'],
+    [90, 'zone-green'],
+    [150, 'zone-green'],
+  ])('percentage %i maps to %s', (percentage, expectedZone) => {
+    expect(getColorZone(percentage)).toBe(expectedZone);
+  });
+});

--- a/src/utils/meal/__tests__/meal-storage.test.ts
+++ b/src/utils/meal/__tests__/meal-storage.test.ts
@@ -1,0 +1,124 @@
+import { TFile, TFolder, Vault } from 'obsidian';
+import { readMeals, writeMeals, getMealsFilePath, ensureMealDirectoryExists } from '../meal-storage';
+import { Meal } from '../../../types/nutrition';
+import { PluginSettings, DEFAULT_SETTINGS } from '../../../types/settings';
+
+function createFakeVault(initialFiles: Record<string, string> = {}) {
+  const files = new Map(Object.entries(initialFiles));
+  const folders = new Set<string>();
+
+  const vault: Vault = {
+    getAbstractFileByPath: jest.fn((path: string) => {
+      if (files.has(path)) return new TFile(path);
+      if (folders.has(path)) return new TFolder(path);
+      return null;
+    }),
+    read: jest.fn(async (file: TFile) => files.get(file.path) ?? ''),
+    modify: jest.fn(async (file: TFile, data: string) => {
+      files.set(file.path, data);
+    }),
+    create: jest.fn(async (path: string, data: string) => {
+      files.set(path, data);
+      return new TFile(path);
+    }),
+    createFolder: jest.fn(async (path: string) => {
+      folders.add(path);
+      return new TFolder(path);
+    }),
+    process: jest.fn(async (file: TFile, fn: (data: string) => string) => {
+      const result = fn(files.get(file.path) ?? '');
+      files.set(file.path, result);
+      return result;
+    }),
+  };
+
+  return { vault, files, folders };
+}
+
+const settings: PluginSettings = { ...DEFAULT_SETTINGS, mealStoragePath: 'tracker/health/food/meals' };
+
+describe('getMealsFilePath', () => {
+  test('joins the meal storage path with meals.json', () => {
+    expect(getMealsFilePath(settings)).toBe('tracker/health/food/meals/meals.json');
+  });
+});
+
+describe('readMeals', () => {
+  test('returns an empty array when the meals file does not exist', async () => {
+    const { vault } = createFakeVault();
+    expect(await readMeals(vault, settings)).toEqual([]);
+  });
+
+  test('returns parsed meals from a valid JSON file', async () => {
+    const meals: Meal[] = [
+      { id: 'm1', name: 'Breakfast', items: [], createdAt: '2026-01-01T00:00:00.000Z', updatedAt: '2026-01-01T00:00:00.000Z' },
+    ];
+    const { vault } = createFakeVault({ 'tracker/health/food/meals/meals.json': JSON.stringify(meals) });
+    expect(await readMeals(vault, settings)).toEqual(meals);
+  });
+
+  test('returns an empty array for malformed JSON instead of throwing', async () => {
+    const { vault } = createFakeVault({ 'tracker/health/food/meals/meals.json': '{ not valid json' });
+    expect(await readMeals(vault, settings)).toEqual([]);
+  });
+
+  test('returns an empty array when the JSON is valid but not an array', async () => {
+    const { vault } = createFakeVault({ 'tracker/health/food/meals/meals.json': JSON.stringify({ oops: true }) });
+    expect(await readMeals(vault, settings)).toEqual([]);
+  });
+});
+
+describe('writeMeals', () => {
+  test('creates the meals file and its directory when none exists yet', async () => {
+    const { vault, files, folders } = createFakeVault();
+    const meals: Meal[] = [
+      { id: 'm1', name: 'Lunch', items: [], createdAt: '2026-01-01T00:00:00.000Z', updatedAt: '2026-01-01T00:00:00.000Z' },
+    ];
+
+    await writeMeals(vault, settings, meals);
+
+    expect(folders.has('tracker/health/food/meals')).toBe(true);
+    expect(JSON.parse(files.get('tracker/health/food/meals/meals.json')!)).toEqual(meals);
+    expect(vault.create).toHaveBeenCalledTimes(1);
+    expect(vault.modify).not.toHaveBeenCalled();
+  });
+
+  test('modifies the existing meals file in place rather than recreating it', async () => {
+    const { vault, files } = createFakeVault({ 'tracker/health/food/meals/meals.json': '[]' });
+    const meals: Meal[] = [
+      { id: 'm1', name: 'Dinner', items: [], createdAt: '2026-01-01T00:00:00.000Z', updatedAt: '2026-01-01T00:00:00.000Z' },
+    ];
+
+    await writeMeals(vault, settings, meals);
+
+    expect(JSON.parse(files.get('tracker/health/food/meals/meals.json')!)).toEqual(meals);
+    expect(vault.modify).toHaveBeenCalledTimes(1);
+    expect(vault.create).not.toHaveBeenCalled();
+  });
+
+  test('write then read round trips the same meals', async () => {
+    const { vault } = createFakeVault();
+    const meals: Meal[] = [
+      { id: 'm1', name: 'Snack', items: [{ food: 'Nuts', quantity: '30g', calories: 180, protein: 6, carbs: 5, fat: 15 }], createdAt: '2026-01-01T00:00:00.000Z', updatedAt: '2026-01-01T00:00:00.000Z' },
+    ];
+
+    await writeMeals(vault, settings, meals);
+    expect(await readMeals(vault, settings)).toEqual(meals);
+  });
+});
+
+describe('ensureMealDirectoryExists', () => {
+  test('creates the folder when it does not exist', async () => {
+    const { vault, folders } = createFakeVault();
+    await ensureMealDirectoryExists(vault, settings);
+    expect(folders.has('tracker/health/food/meals')).toBe(true);
+    expect(vault.createFolder).toHaveBeenCalledTimes(1);
+  });
+
+  test('does nothing when the folder already exists', async () => {
+    const { vault, folders } = createFakeVault();
+    folders.add('tracker/health/food/meals');
+    await ensureMealDirectoryExists(vault, settings);
+    expect(vault.createFolder).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
Pins down current behavior of the code that survives (or gets migrated) in the upcoming refactor, per the spec's Phase 1. No production code changed — tests only.

- **content-parser.ts**: `extractFoodItemsFromContent` round-tripped against `generateCardLayout` output for plain items, multiple items, quotes-in-food-name (`&quot;` escaping), regex-metacharacter-heavy names, unicode/emoji, decimal macros, zero-value macros. `calculateTotals` and `calculatePercentage` (including goal=0).
- **Correction to the spec's assumption**: I empirically probed the "regex metacharacters in food names break matching" claim before writing tests for it, and it doesn't reproduce — `findCardPosition`/`deleteCardFromContent` already escape regex metacharacters correctly. Instead, I found and documented the *actual* reproducible bug: `deleteCardFromContent`'s identity is the `(food, quantity, calories, protein, carbs, fat)` tuple with no id/timestamp, so when two identical entries exist, delete always removes whichever one is first in document order — not necessarily the one the user clicked. That's captured in a documentation test in `content-parser.test.ts`.
- **meal-storage.ts**: read/write round trip against a fake in-memory vault (built on the Phase 0 `obsidian` mock), malformed JSON → `[]`, non-array JSON → `[]`, create-vs-modify branching, directory creation.
- **layout-generator.ts**: snapshot tests of `generateCardLayout`/`generateCTAButtons`/`generateDailySummary`/`generateMealProgressSummaryWithId` using the already-injectable `idGenerator` for determinism, plus `getColorZone` boundary table tests.

50 tests total across 4 suites (16 new from Phase 0 mock coverage + 34 new here... to be precise: 15 + 10 + 20 = 45 new tests in this PR, 5 carried over from Phase 0).

## Test plan
- [x] `npm run build` passes
- [x] `npm test` — 4 suites, 50 tests, all passing
- [x] Snapshots reviewed by hand for correctness (deterministic ids, no `Date.now()` leakage, sane zero-goal handling)