### PR TITLE
Phase 2a: data model, JSON log store, marker-based render

### DIFF
--- a/src/types/nutrition.ts
+++ b/src/types/nutrition.ts
@@ -8,6 +8,7 @@ export interface NutritionData {
 }
 
 export interface FoodItem {
+  id?: string;
   food: string;
   quantity: string;
   calories: number;
@@ -17,6 +18,18 @@ export interface FoodItem {
   emoji?: string;
   timestamp?: string;
   mealId?: string; // Reference to saved meal if this item is from a meal
+}
+
+// A FoodItem persisted in a daily food log's JSON store. Unlike a bare
+// FoodItem, the id is required — it's the stable, render-independent key
+// used to look up an entry for edit/delete.
+export interface FoodLogEntry extends FoodItem {
+  id: string;
+}
+
+export interface FoodLog {
+  date: string;
+  entries: FoodLogEntry[];
 }
 
 export type ServingUnitType = '100g' | 'piece' | 'serving' | 'custom';

--- a/src/utils/__tests__/__snapshots__/layout-generator.test.ts.snap
+++ b/src/utils/__tests__/__snapshots__/layout-generator.test.ts.snap
@@ -8,7 +8,7 @@ exports[`generateCardLayout snapshots (deterministic idGenerator injected) empty
 
 exports[`generateCardLayout snapshots (deterministic idGenerator injected) foodlog context 1`] = `
 "
-<div id="ntr-test-0" class="ntr-food-card" data-ntr-food="Grilled chicken" data-ntr-quantity="150g" data-ntr-calories="250" data-ntr-protein="40" data-ntr-carbs="0" data-ntr-fat="8">
+<div id="ntr-test-0" class="ntr-food-card" data-ntr-id="ntr-test-0" data-ntr-food="Grilled chicken" data-ntr-quantity="150g" data-ntr-calories="250" data-ntr-protein="40" data-ntr-carbs="0" data-ntr-fat="8">
   <div class="ntr-food-card-header">
     <div class="ntr-food-card-info">
       <span class="ntr-food-card-emoji">🍽️</span>
@@ -18,8 +18,8 @@ exports[`generateCardLayout snapshots (deterministic idGenerator injected) foodl
       </div>
     </div>
     <div class="ntr-food-card-actions">
-      <button class="nutrition-edit-btn ntr-edit-btn" data-ntr-food="Grilled chicken" data-ntr-quantity="150g" data-ntr-calories="250" data-ntr-protein="40" data-ntr-carbs="0" data-ntr-fat="8" data-ntr-edit-context="foodlog">✏️ Edit</button>
-      <button class="nutrition-delete-btn ntr-delete-btn" data-ntr-food="Grilled chicken" data-ntr-quantity="150g" data-ntr-calories="250" data-ntr-protein="40" data-ntr-carbs="0" data-ntr-fat="8" data-ntr-edit-context="foodlog" data-ntr-entry-id="ntr-test-0">🗑️ Delete</button>
+      <button class="nutrition-edit-btn ntr-edit-btn" data-ntr-id="ntr-test-0" data-ntr-food="Grilled chicken" data-ntr-quantity="150g" data-ntr-calories="250" data-ntr-protein="40" data-ntr-carbs="0" data-ntr-fat="8" data-ntr-edit-context="foodlog">✏️ Edit</button>
+      <button class="nutrition-delete-btn ntr-delete-btn" data-ntr-id="ntr-test-0" data-ntr-food="Grilled chicken" data-ntr-quantity="150g" data-ntr-calories="250" data-ntr-protein="40" data-ntr-carbs="0" data-ntr-fat="8" data-ntr-edit-context="foodlog" data-ntr-entry-id="ntr-test-0">🗑️ Delete</button>
     </div>
   </div>
   <div class="ntr-stats-grid">
@@ -47,7 +47,7 @@ exports[`generateCardLayout snapshots (deterministic idGenerator injected) foodl
 </div>
 
 
-<div id="ntr-test-1" class="ntr-food-card" data-ntr-food="Brown rice" data-ntr-quantity="100g" data-ntr-calories="130" data-ntr-protein="3" data-ntr-carbs="28" data-ntr-fat="1">
+<div id="ntr-test-1" class="ntr-food-card" data-ntr-id="ntr-test-1" data-ntr-food="Brown rice" data-ntr-quantity="100g" data-ntr-calories="130" data-ntr-protein="3" data-ntr-carbs="28" data-ntr-fat="1">
   <div class="ntr-food-card-header">
     <div class="ntr-food-card-info">
       <span class="ntr-food-card-emoji">🍽️</span>
@@ -57,8 +57,8 @@ exports[`generateCardLayout snapshots (deterministic idGenerator injected) foodl
       </div>
     </div>
     <div class="ntr-food-card-actions">
-      <button class="nutrition-edit-btn ntr-edit-btn" data-ntr-food="Brown rice" data-ntr-quantity="100g" data-ntr-calories="130" data-ntr-protein="3" data-ntr-carbs="28" data-ntr-fat="1" data-ntr-edit-context="foodlog">✏️ Edit</button>
-      <button class="nutrition-delete-btn ntr-delete-btn" data-ntr-food="Brown rice" data-ntr-quantity="100g" data-ntr-calories="130" data-ntr-protein="3" data-ntr-carbs="28" data-ntr-fat="1" data-ntr-edit-context="foodlog" data-ntr-entry-id="ntr-test-1">🗑️ Delete</button>
+      <button class="nutrition-edit-btn ntr-edit-btn" data-ntr-id="ntr-test-1" data-ntr-food="Brown rice" data-ntr-quantity="100g" data-ntr-calories="130" data-ntr-protein="3" data-ntr-carbs="28" data-ntr-fat="1" data-ntr-edit-context="foodlog">✏️ Edit</button>
+      <button class="nutrition-delete-btn ntr-delete-btn" data-ntr-id="ntr-test-1" data-ntr-food="Brown rice" data-ntr-quantity="100g" data-ntr-calories="130" data-ntr-protein="3" data-ntr-carbs="28" data-ntr-fat="1" data-ntr-edit-context="foodlog" data-ntr-entry-id="ntr-test-1">🗑️ Delete</button>
     </div>
   </div>
   <div class="ntr-stats-grid">
@@ -90,7 +90,7 @@ exports[`generateCardLayout snapshots (deterministic idGenerator injected) foodl
 
 exports[`generateCardLayout snapshots (deterministic idGenerator injected) meal context includes the meal add-to-meal CTA and meal id 1`] = `
 "
-<div id="ntr-test-0" class="ntr-food-card" data-ntr-food="Grilled chicken" data-ntr-quantity="150g" data-ntr-calories="250" data-ntr-protein="40" data-ntr-carbs="0" data-ntr-fat="8">
+<div id="ntr-test-0" class="ntr-food-card" data-ntr-id="ntr-test-0" data-ntr-food="Grilled chicken" data-ntr-quantity="150g" data-ntr-calories="250" data-ntr-protein="40" data-ntr-carbs="0" data-ntr-fat="8">
   <div class="ntr-food-card-header">
     <div class="ntr-food-card-info">
       <span class="ntr-food-card-emoji">🍽️</span>
@@ -100,8 +100,8 @@ exports[`generateCardLayout snapshots (deterministic idGenerator injected) meal 
       </div>
     </div>
     <div class="ntr-food-card-actions">
-      <button class="nutrition-edit-btn ntr-edit-btn" data-ntr-food="Grilled chicken" data-ntr-quantity="150g" data-ntr-calories="250" data-ntr-protein="40" data-ntr-carbs="0" data-ntr-fat="8" data-ntr-edit-context="meal">✏️ Edit</button>
-      <button class="nutrition-delete-btn ntr-delete-btn" data-ntr-food="Grilled chicken" data-ntr-quantity="150g" data-ntr-calories="250" data-ntr-protein="40" data-ntr-carbs="0" data-ntr-fat="8" data-ntr-edit-context="meal" data-ntr-entry-id="ntr-test-0">🗑️ Delete</button>
+      <button class="nutrition-edit-btn ntr-edit-btn" data-ntr-id="ntr-test-0" data-ntr-food="Grilled chicken" data-ntr-quantity="150g" data-ntr-calories="250" data-ntr-protein="40" data-ntr-carbs="0" data-ntr-fat="8" data-ntr-edit-context="meal">✏️ Edit</button>
+      <button class="nutrition-delete-btn ntr-delete-btn" data-ntr-id="ntr-test-0" data-ntr-food="Grilled chicken" data-ntr-quantity="150g" data-ntr-calories="250" data-ntr-protein="40" data-ntr-carbs="0" data-ntr-fat="8" data-ntr-edit-context="meal" data-ntr-entry-id="ntr-test-0">🗑️ Delete</button>
     </div>
   </div>
   <div class="ntr-stats-grid">
@@ -129,7 +129,7 @@ exports[`generateCardLayout snapshots (deterministic idGenerator injected) meal 
 </div>
 
 
-<div id="ntr-test-1" class="ntr-food-card" data-ntr-food="Brown rice" data-ntr-quantity="100g" data-ntr-calories="130" data-ntr-protein="3" data-ntr-carbs="28" data-ntr-fat="1">
+<div id="ntr-test-1" class="ntr-food-card" data-ntr-id="ntr-test-1" data-ntr-food="Brown rice" data-ntr-quantity="100g" data-ntr-calories="130" data-ntr-protein="3" data-ntr-carbs="28" data-ntr-fat="1">
   <div class="ntr-food-card-header">
     <div class="ntr-food-card-info">
       <span class="ntr-food-card-emoji">🍽️</span>
@@ -139,8 +139,8 @@ exports[`generateCardLayout snapshots (deterministic idGenerator injected) meal 
       </div>
     </div>
     <div class="ntr-food-card-actions">
-      <button class="nutrition-edit-btn ntr-edit-btn" data-ntr-food="Brown rice" data-ntr-quantity="100g" data-ntr-calories="130" data-ntr-protein="3" data-ntr-carbs="28" data-ntr-fat="1" data-ntr-edit-context="meal">✏️ Edit</button>
-      <button class="nutrition-delete-btn ntr-delete-btn" data-ntr-food="Brown rice" data-ntr-quantity="100g" data-ntr-calories="130" data-ntr-protein="3" data-ntr-carbs="28" data-ntr-fat="1" data-ntr-edit-context="meal" data-ntr-entry-id="ntr-test-1">🗑️ Delete</button>
+      <button class="nutrition-edit-btn ntr-edit-btn" data-ntr-id="ntr-test-1" data-ntr-food="Brown rice" data-ntr-quantity="100g" data-ntr-calories="130" data-ntr-protein="3" data-ntr-carbs="28" data-ntr-fat="1" data-ntr-edit-context="meal">✏️ Edit</button>
+      <button class="nutrition-delete-btn ntr-delete-btn" data-ntr-id="ntr-test-1" data-ntr-food="Brown rice" data-ntr-quantity="100g" data-ntr-calories="130" data-ntr-protein="3" data-ntr-carbs="28" data-ntr-fat="1" data-ntr-edit-context="meal" data-ntr-entry-id="ntr-test-1">🗑️ Delete</button>
     </div>
   </div>
   <div class="ntr-stats-grid">
@@ -172,7 +172,7 @@ exports[`generateCardLayout snapshots (deterministic idGenerator injected) meal 
 
 exports[`generateCardLayout snapshots (deterministic idGenerator injected) no context renders cards without CTA buttons 1`] = `
 "
-<div id="ntr-test-0" class="ntr-food-card" data-ntr-food="Grilled chicken" data-ntr-quantity="150g" data-ntr-calories="250" data-ntr-protein="40" data-ntr-carbs="0" data-ntr-fat="8">
+<div id="ntr-test-0" class="ntr-food-card" data-ntr-id="ntr-test-0" data-ntr-food="Grilled chicken" data-ntr-quantity="150g" data-ntr-calories="250" data-ntr-protein="40" data-ntr-carbs="0" data-ntr-fat="8">
   <div class="ntr-food-card-header">
     <div class="ntr-food-card-info">
       <span class="ntr-food-card-emoji">🍽️</span>
@@ -182,8 +182,8 @@ exports[`generateCardLayout snapshots (deterministic idGenerator injected) no co
       </div>
     </div>
     <div class="ntr-food-card-actions">
-      <button class="nutrition-edit-btn ntr-edit-btn" data-ntr-food="Grilled chicken" data-ntr-quantity="150g" data-ntr-calories="250" data-ntr-protein="40" data-ntr-carbs="0" data-ntr-fat="8" data-ntr-edit-context="foodlog">✏️ Edit</button>
-      <button class="nutrition-delete-btn ntr-delete-btn" data-ntr-food="Grilled chicken" data-ntr-quantity="150g" data-ntr-calories="250" data-ntr-protein="40" data-ntr-carbs="0" data-ntr-fat="8" data-ntr-edit-context="foodlog" data-ntr-entry-id="ntr-test-0">🗑️ Delete</button>
+      <button class="nutrition-edit-btn ntr-edit-btn" data-ntr-id="ntr-test-0" data-ntr-food="Grilled chicken" data-ntr-quantity="150g" data-ntr-calories="250" data-ntr-protein="40" data-ntr-carbs="0" data-ntr-fat="8" data-ntr-edit-context="foodlog">✏️ Edit</button>
+      <button class="nutrition-delete-btn ntr-delete-btn" data-ntr-id="ntr-test-0" data-ntr-food="Grilled chicken" data-ntr-quantity="150g" data-ntr-calories="250" data-ntr-protein="40" data-ntr-carbs="0" data-ntr-fat="8" data-ntr-edit-context="foodlog" data-ntr-entry-id="ntr-test-0">🗑️ Delete</button>
     </div>
   </div>
   <div class="ntr-stats-grid">
@@ -211,7 +211,7 @@ exports[`generateCardLayout snapshots (deterministic idGenerator injected) no co
 </div>
 
 
-<div id="ntr-test-1" class="ntr-food-card" data-ntr-food="Brown rice" data-ntr-quantity="100g" data-ntr-calories="130" data-ntr-protein="3" data-ntr-carbs="28" data-ntr-fat="1">
+<div id="ntr-test-1" class="ntr-food-card" data-ntr-id="ntr-test-1" data-ntr-food="Brown rice" data-ntr-quantity="100g" data-ntr-calories="130" data-ntr-protein="3" data-ntr-carbs="28" data-ntr-fat="1">
   <div class="ntr-food-card-header">
     <div class="ntr-food-card-info">
       <span class="ntr-food-card-emoji">🍽️</span>
@@ -221,8 +221,8 @@ exports[`generateCardLayout snapshots (deterministic idGenerator injected) no co
       </div>
     </div>
     <div class="ntr-food-card-actions">
-      <button class="nutrition-edit-btn ntr-edit-btn" data-ntr-food="Brown rice" data-ntr-quantity="100g" data-ntr-calories="130" data-ntr-protein="3" data-ntr-carbs="28" data-ntr-fat="1" data-ntr-edit-context="foodlog">✏️ Edit</button>
-      <button class="nutrition-delete-btn ntr-delete-btn" data-ntr-food="Brown rice" data-ntr-quantity="100g" data-ntr-calories="130" data-ntr-protein="3" data-ntr-carbs="28" data-ntr-fat="1" data-ntr-edit-context="foodlog" data-ntr-entry-id="ntr-test-1">🗑️ Delete</button>
+      <button class="nutrition-edit-btn ntr-edit-btn" data-ntr-id="ntr-test-1" data-ntr-food="Brown rice" data-ntr-quantity="100g" data-ntr-calories="130" data-ntr-protein="3" data-ntr-carbs="28" data-ntr-fat="1" data-ntr-edit-context="foodlog">✏️ Edit</button>
+      <button class="nutrition-delete-btn ntr-delete-btn" data-ntr-id="ntr-test-1" data-ntr-food="Brown rice" data-ntr-quantity="100g" data-ntr-calories="130" data-ntr-protein="3" data-ntr-carbs="28" data-ntr-fat="1" data-ntr-edit-context="foodlog" data-ntr-entry-id="ntr-test-1">🗑️ Delete</button>
     </div>
   </div>
   <div class="ntr-stats-grid">

--- a/src/utils/__tests__/layout-generator.test.ts
+++ b/src/utils/__tests__/layout-generator.test.ts
@@ -43,6 +43,36 @@ describe('generateCardLayout snapshots (deterministic idGenerator injected)', ()
   });
 });
 
+describe('stable ids from data', () => {
+  test('an item carrying its own id uses that id instead of generating one', () => {
+    const idGenerator = makeDeterministicIdGenerator();
+    const itemsWithIds: FoodItem[] = [
+      { id: 'stable-id-1', food: 'Grilled chicken', quantity: '150g', calories: 250, protein: 40, carbs: 0, fat: 8 },
+    ];
+    const content = generateCardLayout(itemsWithIds, goals, 'foodlog', undefined, idGenerator);
+
+    expect(content).toContain('data-ntr-id="stable-id-1"');
+    expect(content).not.toContain('ntr-test-0');
+  });
+
+  test('re-rendering the same item with the same id twice produces byte-identical card markup', () => {
+    const itemsWithIds: FoodItem[] = [
+      { id: 'stable-id-1', food: 'Grilled chicken', quantity: '150g', calories: 250, protein: 40, carbs: 0, fat: 8 },
+    ];
+
+    const firstRender = generateCardLayout(itemsWithIds, goals, 'foodlog', undefined, makeDeterministicIdGenerator());
+    const secondRender = generateCardLayout(itemsWithIds, goals, 'foodlog', undefined, makeDeterministicIdGenerator());
+
+    expect(firstRender).toBe(secondRender);
+  });
+
+  test('items without an id still fall back to the injected idGenerator (unmigrated callers keep working)', () => {
+    const content = generateCardLayout(items, goals, 'foodlog', undefined, makeDeterministicIdGenerator());
+    expect(content).toContain('data-ntr-id="ntr-test-0"');
+    expect(content).toContain('data-ntr-id="ntr-test-1"');
+  });
+});
+
 describe('generateCTAButtons snapshots', () => {
   test('foodlog CTA', () => {
     expect(generateCTAButtons('foodlog', undefined, makeDeterministicIdGenerator())).toMatchSnapshot();

--- a/src/utils/__tests__/marker-region.test.ts
+++ b/src/utils/__tests__/marker-region.test.ts
@@ -1,0 +1,65 @@
+import { wrapInMarkers, replaceMarkedRegion, NTR_MARKER_BEGIN, NTR_MARKER_END } from '../content-parser';
+
+describe('wrapInMarkers', () => {
+  test('wraps content between begin and end markers', () => {
+    expect(wrapInMarkers('generated stuff')).toBe('%% ntr:begin %%\ngenerated stuff\n%% ntr:end %%');
+  });
+});
+
+describe('replaceMarkedRegion', () => {
+  test('appends a new marked region when none exists in empty content', () => {
+    expect(replaceMarkedRegion('', 'cards go here')).toBe(wrapInMarkers('cards go here'));
+  });
+
+  test('appends a new marked region after existing user content when none exists yet', () => {
+    const content = '# My Food Log\n\nSome notes I wrote by hand.';
+    const result = replaceMarkedRegion(content, 'cards go here');
+    expect(result).toBe(`${content}\n\n${wrapInMarkers('cards go here')}`);
+  });
+
+  test('replaces only the content between existing markers, preserving text before and after', () => {
+    const content = [
+      '# My Food Log',
+      '',
+      'A note I wrote above the generated region.',
+      '',
+      NTR_MARKER_BEGIN,
+      'old generated cards',
+      NTR_MARKER_END,
+      '',
+      'A note I wrote below the generated region.',
+    ].join('\n');
+
+    const result = replaceMarkedRegion(content, 'new generated cards');
+
+    expect(result).toBe([
+      '# My Food Log',
+      '',
+      'A note I wrote above the generated region.',
+      '',
+      NTR_MARKER_BEGIN,
+      'new generated cards',
+      NTR_MARKER_END,
+      '',
+      'A note I wrote below the generated region.',
+    ].join('\n'));
+  });
+
+  test('re-rendering twice in a row is idempotent for unchanged input', () => {
+    const initial = replaceMarkedRegion('# Log\n\nUser note.', 'cards v1');
+    const rerendered = replaceMarkedRegion(initial, 'cards v1');
+    expect(rerendered).toBe(initial);
+  });
+
+  test('updating the generated region does not disturb surrounding user content across repeated edits', () => {
+    let content = replaceMarkedRegion('# Log\n\nUser note above.\n\nUser note below.', 'cards v1');
+    content = replaceMarkedRegion(content, 'cards v2');
+    content = replaceMarkedRegion(content, 'cards v3');
+
+    expect(content).toContain('User note above.');
+    expect(content).toContain('User note below.');
+    expect(content).toContain('cards v3');
+    expect(content).not.toContain('cards v1');
+    expect(content).not.toContain('cards v2');
+  });
+});

--- a/src/utils/content-parser.ts
+++ b/src/utils/content-parser.ts
@@ -188,3 +188,26 @@ export function deleteCardFromContent(content: string, itemToDelete: { food: str
 
   return extractCompleteCard(content, match.index);
 }
+
+// The generated region (cards + progress summary) is wrapped in these markers so a full
+// re-render can replace it in place without touching user-authored content above/below.
+export const NTR_MARKER_BEGIN = '%% ntr:begin %%';
+export const NTR_MARKER_END = '%% ntr:end %%';
+
+export function wrapInMarkers(generatedContent: string): string {
+  return `${NTR_MARKER_BEGIN}\n${generatedContent}\n${NTR_MARKER_END}`;
+}
+
+export function replaceMarkedRegion(content: string, newRegionContent: string): string {
+  const beginIndex = content.indexOf(NTR_MARKER_BEGIN);
+  const endIndex = content.indexOf(NTR_MARKER_END);
+
+  if (beginIndex === -1 || endIndex === -1 || endIndex < beginIndex) {
+    const separator = content.trim().length > 0 ? '\n\n' : '';
+    return content + separator + wrapInMarkers(newRegionContent);
+  }
+
+  const before = content.slice(0, beginIndex);
+  const after = content.slice(endIndex + NTR_MARKER_END.length);
+  return before + wrapInMarkers(newRegionContent) + after;
+}

--- a/src/utils/food-log/__tests__/food-log-storage.test.ts
+++ b/src/utils/food-log/__tests__/food-log-storage.test.ts
@@ -1,0 +1,125 @@
+import { TFile, TFolder, Vault } from 'obsidian';
+import { readFoodLog, writeFoodLog, getFoodLogFilePath, ensureFoodLogDirectoryExists } from '../food-log-storage';
+import { FoodLog } from '../../../types/nutrition';
+import { PluginSettings, DEFAULT_SETTINGS } from '../../../types/settings';
+
+function createFakeVault(initialFiles: Record<string, string> = {}) {
+  const files = new Map(Object.entries(initialFiles));
+  const folders = new Set<string>();
+
+  const vault: Vault = {
+    getAbstractFileByPath: jest.fn((path: string) => {
+      if (files.has(path)) return new TFile(path);
+      if (folders.has(path)) return new TFolder(path);
+      return null;
+    }),
+    read: jest.fn(async (file: TFile) => files.get(file.path) ?? ''),
+    modify: jest.fn(async (file: TFile, data: string) => {
+      files.set(file.path, data);
+    }),
+    create: jest.fn(async (path: string, data: string) => {
+      files.set(path, data);
+      return new TFile(path);
+    }),
+    createFolder: jest.fn(async (path: string) => {
+      folders.add(path);
+      return new TFolder(path);
+    }),
+    process: jest.fn(async (file: TFile, fn: (data: string) => string) => {
+      const result = fn(files.get(file.path) ?? '');
+      files.set(file.path, result);
+      return result;
+    }),
+  };
+
+  return { vault, files, folders };
+}
+
+const settings: PluginSettings = { ...DEFAULT_SETTINGS, logStoragePath: 'tracker/health/food/log' };
+
+describe('getFoodLogFilePath', () => {
+  test('nests the dated JSON file under a .data directory', () => {
+    expect(getFoodLogFilePath(settings, '2026-07-13')).toBe('tracker/health/food/log/.data/2026-07-13.json');
+  });
+});
+
+describe('readFoodLog', () => {
+  test('returns an empty log when the file does not exist', async () => {
+    const { vault } = createFakeVault();
+    expect(await readFoodLog(vault, settings, '2026-07-13')).toEqual({ date: '2026-07-13', entries: [] });
+  });
+
+  test('returns parsed entries from a valid JSON file', async () => {
+    const log: FoodLog = {
+      date: '2026-07-13',
+      entries: [{ id: 'e1', food: 'Oats', quantity: '50g', calories: 190, protein: 7, carbs: 33, fat: 3 }],
+    };
+    const { vault } = createFakeVault({ 'tracker/health/food/log/.data/2026-07-13.json': JSON.stringify(log) });
+    expect(await readFoodLog(vault, settings, '2026-07-13')).toEqual(log);
+  });
+
+  test('returns an empty log for malformed JSON instead of throwing', async () => {
+    const { vault } = createFakeVault({ 'tracker/health/food/log/.data/2026-07-13.json': '{ not valid' });
+    expect(await readFoodLog(vault, settings, '2026-07-13')).toEqual({ date: '2026-07-13', entries: [] });
+  });
+
+  test('returns an empty log when entries is missing or not an array', async () => {
+    const { vault } = createFakeVault({ 'tracker/health/food/log/.data/2026-07-13.json': JSON.stringify({ date: '2026-07-13' }) });
+    expect(await readFoodLog(vault, settings, '2026-07-13')).toEqual({ date: '2026-07-13', entries: [] });
+  });
+});
+
+describe('writeFoodLog', () => {
+  test('creates the file and its .data directory when none exists yet', async () => {
+    const { vault, files, folders } = createFakeVault();
+    const log: FoodLog = { date: '2026-07-13', entries: [] };
+
+    await writeFoodLog(vault, settings, log);
+
+    expect(folders.has('tracker/health/food/log/.data')).toBe(true);
+    expect(JSON.parse(files.get('tracker/health/food/log/.data/2026-07-13.json')!)).toEqual(log);
+    expect(vault.create).toHaveBeenCalledTimes(1);
+    expect(vault.modify).not.toHaveBeenCalled();
+  });
+
+  test('modifies the existing file in place rather than recreating it', async () => {
+    const { vault, files } = createFakeVault({ 'tracker/health/food/log/.data/2026-07-13.json': '{"date":"2026-07-13","entries":[]}' });
+    const log: FoodLog = { date: '2026-07-13', entries: [{ id: 'e1', food: 'Egg', quantity: '2', calories: 140, protein: 12, carbs: 1, fat: 10 }] };
+
+    await writeFoodLog(vault, settings, log);
+
+    expect(JSON.parse(files.get('tracker/health/food/log/.data/2026-07-13.json')!)).toEqual(log);
+    expect(vault.modify).toHaveBeenCalledTimes(1);
+    expect(vault.create).not.toHaveBeenCalled();
+  });
+
+  test('write then read round trips the same log', async () => {
+    const { vault } = createFakeVault();
+    const log: FoodLog = {
+      date: '2026-07-13',
+      entries: [
+        { id: 'e1', food: 'Egg', quantity: '2 pcs', calories: 140, protein: 12, carbs: 1, fat: 10, timestamp: '2026-07-13T08:00:00.000Z' },
+        { id: 'e2', food: 'Egg', quantity: '2 pcs', calories: 140, protein: 12, carbs: 1, fat: 10, timestamp: '2026-07-13T18:00:00.000Z' },
+      ],
+    };
+
+    await writeFoodLog(vault, settings, log);
+    expect(await readFoodLog(vault, settings, '2026-07-13')).toEqual(log);
+  });
+});
+
+describe('ensureFoodLogDirectoryExists', () => {
+  test('creates the .data folder when it does not exist', async () => {
+    const { vault, folders } = createFakeVault();
+    await ensureFoodLogDirectoryExists(vault, settings);
+    expect(folders.has('tracker/health/food/log/.data')).toBe(true);
+    expect(vault.createFolder).toHaveBeenCalledTimes(1);
+  });
+
+  test('does nothing when the folder already exists', async () => {
+    const { vault, folders } = createFakeVault();
+    folders.add('tracker/health/food/log/.data');
+    await ensureFoodLogDirectoryExists(vault, settings);
+    expect(vault.createFolder).not.toHaveBeenCalled();
+  });
+});

--- a/src/utils/food-log/food-log-storage.ts
+++ b/src/utils/food-log/food-log-storage.ts
@@ -1,0 +1,51 @@
+import { Vault, TFile, normalizePath } from 'obsidian';
+import { FoodLog } from '../../types/nutrition';
+import { PluginSettings } from '../../types/settings';
+
+export function getFoodLogFilePath(settings: PluginSettings, date: string): string {
+  return normalizePath(`${settings.logStoragePath}/.data/${date}.json`);
+}
+
+export async function ensureFoodLogDirectoryExists(vault: Vault, settings: PluginSettings): Promise<void> {
+  const path = normalizePath(`${settings.logStoragePath}/.data`);
+  const exists = vault.getAbstractFileByPath(path);
+  if (!exists) {
+    await vault.createFolder(path);
+  }
+}
+
+export async function readFoodLog(vault: Vault, settings: PluginSettings, date: string): Promise<FoodLog> {
+  try {
+    const logPath = getFoodLogFilePath(settings, date);
+    const logFile = vault.getAbstractFileByPath(logPath);
+
+    if (!logFile || !(logFile instanceof TFile)) {
+      return { date, entries: [] };
+    }
+
+    const content = await vault.read(logFile);
+    const log = JSON.parse(content);
+
+    if (!log || !Array.isArray(log.entries)) {
+      return { date, entries: [] };
+    }
+
+    return { date, entries: log.entries };
+  } catch (error) {
+    console.error('Error reading food log:', error);
+    return { date, entries: [] };
+  }
+}
+
+export async function writeFoodLog(vault: Vault, settings: PluginSettings, log: FoodLog): Promise<void> {
+  const logPath = getFoodLogFilePath(settings, log.date);
+  const content = JSON.stringify(log, null, 2);
+  const existingFile = vault.getAbstractFileByPath(logPath);
+
+  if (existingFile instanceof TFile) {
+    await vault.modify(existingFile, content);
+  } else {
+    await ensureFoodLogDirectoryExists(vault, settings);
+    await vault.create(logPath, content);
+  }
+}

--- a/src/utils/layout-generator.ts
+++ b/src/utils/layout-generator.ts
@@ -26,8 +26,8 @@ export function generateCardLayout(
 
     const editContext = context || 'foodlog';
 
-    const entryId = idGenerator('ntr');
-    content += `\n<div id="${entryId}" class="ntr-food-card" data-ntr-food="${item.food.replace(/"/g, '&quot;')}" data-ntr-quantity="${item.quantity.replace(/"/g, '&quot;')}" data-ntr-calories="${item.calories}" data-ntr-protein="${item.protein}" data-ntr-carbs="${item.carbs}" data-ntr-fat="${item.fat}">\n`;
+    const entryId = item.id ?? idGenerator('ntr');
+    content += `\n<div id="${entryId}" class="ntr-food-card" data-ntr-id="${entryId}" data-ntr-food="${item.food.replace(/"/g, '&quot;')}" data-ntr-quantity="${item.quantity.replace(/"/g, '&quot;')}" data-ntr-calories="${item.calories}" data-ntr-protein="${item.protein}" data-ntr-carbs="${item.carbs}" data-ntr-fat="${item.fat}">\n`;
     content += `  <div class="ntr-food-card-header">\n`;
     content += `    <div class="ntr-food-card-info">\n`;
     content += `      <span class="ntr-food-card-emoji">${emoji}</span>\n`;
@@ -40,8 +40,8 @@ export function generateCardLayout(
     content += `      </div>\n`;
     content += `    </div>\n`;
     content += `    <div class="ntr-food-card-actions">\n`;
-    content += `      <button class="nutrition-edit-btn ntr-edit-btn" data-ntr-food="${item.food.replace(/"/g, '&quot;')}" data-ntr-quantity="${item.quantity.replace(/"/g, '&quot;')}" data-ntr-calories="${item.calories}" data-ntr-protein="${item.protein}" data-ntr-carbs="${item.carbs}" data-ntr-fat="${item.fat}" data-ntr-edit-context="${editContext}">✏️ Edit</button>\n`;
-    content += `      <button class="nutrition-delete-btn ntr-delete-btn" data-ntr-food="${item.food.replace(/"/g, '&quot;')}" data-ntr-quantity="${item.quantity.replace(/"/g, '&quot;')}" data-ntr-calories="${item.calories}" data-ntr-protein="${item.protein}" data-ntr-carbs="${item.carbs}" data-ntr-fat="${item.fat}" data-ntr-edit-context="${editContext}" data-ntr-entry-id="${entryId}">🗑️ Delete</button>\n`;
+    content += `      <button class="nutrition-edit-btn ntr-edit-btn" data-ntr-id="${entryId}" data-ntr-food="${item.food.replace(/"/g, '&quot;')}" data-ntr-quantity="${item.quantity.replace(/"/g, '&quot;')}" data-ntr-calories="${item.calories}" data-ntr-protein="${item.protein}" data-ntr-carbs="${item.carbs}" data-ntr-fat="${item.fat}" data-ntr-edit-context="${editContext}">✏️ Edit</button>\n`;
+    content += `      <button class="nutrition-delete-btn ntr-delete-btn" data-ntr-id="${entryId}" data-ntr-food="${item.food.replace(/"/g, '&quot;')}" data-ntr-quantity="${item.quantity.replace(/"/g, '&quot;')}" data-ntr-calories="${item.calories}" data-ntr-protein="${item.protein}" data-ntr-carbs="${item.carbs}" data-ntr-fat="${item.fat}" data-ntr-edit-context="${editContext}" data-ntr-entry-id="${entryId}">🗑️ Delete</button>\n`;
     content += `    </div>\n`;
     content += `  </div>\n`;
 


### PR DESCRIPTION
## Summary
First slice of the single-source-of-truth refactor. This PR is purely additive: new types, a new JSON store, and a change to how entry ids are sourced — no existing create/edit/delete flow is rewired yet, and no old parsing code is removed. Build and all existing tests stay green throughout, verified commit by commit.

- **Types**: `FoodLogEntry` (a `FoodItem` with a required `id`) and `FoodLog` (`{ date, entries }`) in `src/types/nutrition.ts`. `FoodItem.id` is now optional on the base type.
- **JSON store for daily logs**: `src/utils/food-log/food-log-storage.ts`, mirroring the existing `meal-storage.ts` pattern. Chose one file per date at `{logStoragePath}/.data/{date}.json` (documenting the implementer's-choice call from the spec) — this mirrors the existing per-date markdown note (`{logStoragePath}/{date}.md`) rather than one growing `food-logs.json`.
- **Stable ids in the renderer**: `layout-generator.ts` now does `item.id ?? idGenerator('ntr')` and writes the result into a new `data-ntr-id` attribute on the card div and both edit/delete buttons. Backward compatible — no current caller sets `.id` yet, so existing callers keep generating fresh ids exactly as before. New tests prove: an item with an id uses it verbatim, re-rendering the same id twice is byte-identical, and id-less items still fall back correctly.
- **Marker-region helper**: `wrapInMarkers`/`replaceMarkedRegion`/`NTR_MARKER_BEGIN`/`NTR_MARKER_END` added to `content-parser.ts` (the file's eventual home per the spec, once the old regex-splicing functions are deleted in the next PR). `replaceMarkedRegion` swaps only the content between `%% ntr:begin %%`/`%% ntr:end %%`, leaving user-authored text above/below untouched, and appends a fresh marked region when none exists yet.

Not in this PR (next PR, "ID-based edit/delete"): wiring `main.ts`'s edit/delete buttons to `data-ntr-id`, cutting `food-log/manager.ts` over to `writeFoodLog` + `replaceMarkedRegion` + `vault.process`, and deleting `findCardPosition`/`findCardBounds`/`deleteCardFromContent`/`replaceInExistingLog`/`appendToExistingLog`.

## Test plan
- [x] `npm run build` passes after every commit
- [x] `npm test` — 6 suites, 69 tests, all passing (19 new: 10 for the JSON store, 3 for stable ids, 6 for the marker helper)
- [x] Existing Phase 1 snapshots updated and hand-reviewed — the only diff is the new `data-ntr-id` attribute