### PR TITLE
Phase 2c: one-way meal sync, remove listener machinery

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -15,8 +15,6 @@ export default class NutritionTrackerPlugin extends Plugin {
   private editButtonHandler: (event: Event) => void;
   private deleteButtonHandler: (event: Event) => void;
   private ctaButtonHandler: (event: Event) => void;
-  private mealSyncTimeouts: Map<string, number> = new Map();
-  private isDeleteInProgress: boolean = false;
   private currentModal: FoodInputModal | null = null;
 
   private get ctx(): PluginContext {
@@ -69,11 +67,10 @@ export default class NutritionTrackerPlugin extends Plugin {
 
     // Set up event delegation for edit buttons
     this.setupEditButtonEventHandling();
-    
-    // Set up file modification listener for meal notes
-    this.setupMealNoteSyncHandler();
 
-    // Set up file rename listener
+    // Set up file rename listener — meal notes are renamed through the plugin's
+    // modal, not by hand-editing content, but the file itself can still be renamed
+    // in Obsidian's file explorer, so the meal's name in JSON is kept in sync with it.
     this.registerEvent(
       this.app.vault.on('rename', async (file, oldPath) => {
         if (file instanceof TFile) {
@@ -84,11 +81,6 @@ export default class NutritionTrackerPlugin extends Plugin {
   }
 
   onunload() {
-    this.mealSyncTimeouts.forEach(timeout => window.clearTimeout(timeout));
-    this.mealSyncTimeouts.clear();
-    
-    this.isDeleteInProgress = false;
-    
     if (this.currentModal) {
       this.currentModal.close();
       this.currentModal = null;
@@ -100,24 +92,6 @@ export default class NutritionTrackerPlugin extends Plugin {
       this.currentModal.close();
       this.currentModal = null;
     }
-    
-    const existingModalContainers = document.querySelectorAll('.modal-container.mod-dim');
-    const existingModalContent = document.querySelectorAll('.nutrition-tracker-modal');
-    
-    existingModalContainers.forEach(modal => {
-      if (modal.querySelector('.nutrition-tracker-modal')) {
-        modal.remove();
-      }
-    });
-
-    existingModalContent.forEach(modal => {
-      const container = modal.closest('.modal-container');
-      if (container) {
-        container.remove();
-      } else {
-        modal.remove();
-      }
-    });
   }
 
   private createAndOpenModal(setupFn?: (modal: FoodInputModal) => void) {
@@ -227,20 +201,14 @@ export default class NutritionTrackerPlugin extends Plugin {
         event.preventDefault();
         event.stopPropagation();
         event.stopImmediatePropagation();
-        
-        if (this.isDeleteInProgress) {
-          return;
-        }
-        
+
         if (target.hasAttribute('data-processing') || (target as HTMLButtonElement).disabled) {
           return;
         }
-        
-        this.isDeleteInProgress = true;
+
         target.setAttribute('data-processing', 'true');
         target.classList.add('disabled');
-        
-        
+
         try {
           const id = target.getAttribute('data-ntr-id') || '';
           const food = target.getAttribute('data-ntr-food') || '';
@@ -269,10 +237,9 @@ export default class NutritionTrackerPlugin extends Plugin {
           console.error('💥 Error in delete handler:', error);
         } finally {
           setTimeout(() => {
-            this.isDeleteInProgress = false;
             target.removeAttribute('data-processing');
             target.classList.remove('disabled');
-          }, 100); 
+          }, 100);
         }
       }
     };
@@ -304,30 +271,6 @@ export default class NutritionTrackerPlugin extends Plugin {
     this.registerDomEvent(document, 'click', this.editButtonHandler);
     this.registerDomEvent(document, 'click', this.deleteButtonHandler);
     this.registerDomEvent(document, 'click', this.ctaButtonHandler);
-  }
-
-  private setupMealNoteSyncHandler() {
-    this.registerEvent(
-      this.app.vault.on('modify', (file) => {
-        const isMealNote = MealOps.isMealNote(this.ctx, file);
-
-        if (isMealNote && file instanceof TFile) {
-          const filePath = file.path;
-
-          if (this.mealSyncTimeouts.has(filePath)) {
-            window.clearTimeout(this.mealSyncTimeouts.get(filePath));
-          }
-
-          const timeout = window.setTimeout(() => {
-            void MealOps.syncMealNoteToJSON(this.ctx, file).then(() => {
-              this.mealSyncTimeouts.delete(filePath);
-            });
-          }, 1000);
-
-          this.mealSyncTimeouts.set(filePath, timeout);
-        }
-      })
-    );
   }
 
   async loadSettings() {

--- a/src/utils/meal/__tests__/manager.test.ts
+++ b/src/utils/meal/__tests__/manager.test.ts
@@ -1,5 +1,5 @@
 import { Vault } from 'obsidian';
-import { updateMealItem, deleteMealItem, addItemsToMeal } from '../manager';
+import { updateMealItem, deleteMealItem, addItemsToMeal, handleFileRename } from '../manager';
 import { Meal } from '../../../types/nutrition';
 import { PluginContext } from '../../../types/plugin-context';
 import { PluginSettings, DEFAULT_SETTINGS } from '../../../types/settings';
@@ -101,5 +101,84 @@ describe('addItemsToMeal — assigns ids to newly added items', () => {
       expect(typeof id).toBe('string');
       expect(id!.length).toBeGreaterThan(0);
     }
+  });
+});
+
+describe('handleFileRename — path/JSON based, no content parsing', () => {
+  function meal(overrides: Partial<Meal> = {}): Meal {
+    return {
+      id: 'meal-1',
+      name: 'Breakfast Bowl',
+      items: [],
+      createdAt: '2026-07-13T00:00:00.000Z',
+      updatedAt: '2026-07-13T00:00:00.000Z',
+      version: 2,
+      ...overrides,
+    };
+  }
+
+  test('a hand-rename in the file explorer updates the meal name in JSON', async () => {
+    const { vault, files } = createFakeVault(mealsFile([meal()]));
+
+    await handleFileRename(
+      makeCtx(vault),
+      'tracker/health/food/meals/breakfast-bowl.md',
+      'tracker/health/food/meals/morning-bowl.md'
+    );
+
+    const savedMeals: Meal[] = JSON.parse(files.get('tracker/health/food/meals/meals.json')!);
+    expect(savedMeals[0].name).toBe('Morning Bowl');
+  });
+
+  test('is a no-op when the name already matches (self-triggered by a UI-driven rename)', async () => {
+    // Simulates updateMeal's flow: JSON is written with the new name BEFORE the file is
+    // renamed, so by the time the vault "rename" event fires, sanitizeMealName(name) no
+    // longer matches the old filename — handleFileRename must not touch the JSON again.
+    const { vault, files } = createFakeVault(mealsFile([meal({ name: 'Morning Bowl' })]));
+    const before = files.get('tracker/health/food/meals/meals.json');
+
+    await handleFileRename(
+      makeCtx(vault),
+      'tracker/health/food/meals/breakfast-bowl.md',
+      'tracker/health/food/meals/morning-bowl.md'
+    );
+
+    expect(files.get('tracker/health/food/meals/meals.json')).toBe(before);
+  });
+
+  test('ignores renames outside the meal storage path', async () => {
+    const { vault, files } = createFakeVault(mealsFile([meal()]));
+    const before = files.get('tracker/health/food/meals/meals.json');
+
+    await handleFileRename(makeCtx(vault), 'tracker/health/food/log/2026-07-13.md', 'tracker/health/food/log/renamed.md');
+
+    expect(files.get('tracker/health/food/meals/meals.json')).toBe(before);
+  });
+
+  test('ignores a rename that does not match any tracked meal', async () => {
+    const { vault, files } = createFakeVault(mealsFile([meal()]));
+    const before = files.get('tracker/health/food/meals/meals.json');
+
+    await handleFileRename(
+      makeCtx(vault),
+      'tracker/health/food/meals/some-orphaned-note.md',
+      'tracker/health/food/meals/renamed-orphan.md'
+    );
+
+    expect(files.get('tracker/health/food/meals/meals.json')).toBe(before);
+  });
+
+  test('does not create or modify a note file — only meals.json is touched', async () => {
+    const { vault, files } = createFakeVault(mealsFile([meal()]));
+
+    await handleFileRename(
+      makeCtx(vault),
+      'tracker/health/food/meals/breakfast-bowl.md',
+      'tracker/health/food/meals/morning-bowl.md'
+    );
+
+    expect(vault.create).not.toHaveBeenCalled();
+    expect(files.size).toBe(1); // only meals.json exists — no .md note was ever created
+    expect([...files.keys()]).toEqual(['tracker/health/food/meals/meals.json']);
   });
 });

--- a/src/utils/meal/manager.ts
+++ b/src/utils/meal/manager.ts
@@ -1,9 +1,8 @@
-import { TFile, Notice, TAbstractFile, normalizePath } from 'obsidian';
+import { TFile, Notice, normalizePath } from 'obsidian';
 import { FoodItem, Meal } from '../../types/nutrition';
 import { PluginContext } from '../../types/plugin-context';
 import * as FileUtils from '../file';
 import * as LayoutGenerator from '../layout-generator';
-import * as ContentParser from '../content-parser';
 import { readMeals, writeMeals } from './meal-storage';
 import { migrateMealToV2, isLegacyMeal, calculateTotalNutrition } from './meal-operations';
 
@@ -167,62 +166,6 @@ function generateMealNoteContent(ctx: PluginContext, meal: Meal): string {
   return content;
 }
 
-export function isMealNote(ctx: PluginContext, file: TAbstractFile): boolean {
-  return FileUtils.isMealNote(file, ctx.settings.mealStoragePath, ctx.settings.logStoragePath);
-}
-
-export async function syncMealNoteToJSON(ctx: PluginContext, file: TFile): Promise<void> {
-  try {
-    const content = await ctx.vault.read(file);
-
-    if (!content.includes('data-meal-id="')) {
-      return;
-    }
-
-    const parsedMeal = ContentParser.parseMealFromMarkdown(content);
-
-    if (!parsedMeal) {
-      return;
-    }
-
-    const filename = file.path.split('/').pop()?.replace('.md', '') || '';
-    const mealName = FileUtils.convertFilenameToReadableName(filename);
-
-    const meals = await getMeals(ctx);
-    const mealIndex = meals.findIndex(m => m.id === parsedMeal.id);
-
-    if (mealIndex >= 0) {
-      const oldMeal = meals[mealIndex];
-
-      const nameChanged = oldMeal.name !== mealName;
-
-      const updatedMeal = {
-        ...oldMeal,
-        name: mealName,
-        items: parsedMeal.items || oldMeal.items,
-        description: parsedMeal.description !== undefined ? parsedMeal.description : oldMeal.description,
-        updatedAt: new Date().toISOString()
-      };
-
-      meals[mealIndex] = updatedMeal;
-      await writeMeals(ctx.vault, ctx.settings, meals);
-
-      if (!nameChanged) {
-        return;
-      }
-
-      await handleMealNameChange(ctx, oldMeal, updatedMeal, file);
-      new Notice(`✅ Meal updated: "${oldMeal.name}" → "${updatedMeal.name}"`);
-    } else {
-      new Notice("⚠️ meal not found in storage - this might be an orphaned meal note");
-    }
-
-  } catch (error) {
-    new Notice(`❌ Failed to sync meal changes: ${error.message}`);
-    throw error;
-  }
-}
-
 export async function updateMealItem(ctx: PluginContext, entryId: string, newItem: FoodItem): Promise<void> {
   try {
     const meals = await getMeals(ctx);
@@ -353,29 +296,18 @@ async function handleMealNameChange(ctx: PluginContext, oldMeal: Meal, newMeal: 
 
 export async function handleFileRename(ctx: PluginContext, oldPath: string, newPath: string): Promise<void> {
   try {
-    const newFilename = newPath.split('/').pop()?.replace('.md', '') || '';
-
     if (!newPath.startsWith(ctx.settings.mealStoragePath) || !oldPath.startsWith(ctx.settings.mealStoragePath)) {
       return;
     }
 
-    const file = ctx.vault.getAbstractFileByPath(newPath);
-    if (!(file instanceof TFile)) {
-      return;
-    }
-
-    const content = await ctx.vault.read(file);
-    if (!content.includes('data-meal-id="')) {
-      return;
-    }
-
-    const parsedMeal = ContentParser.parseMealFromMarkdown(content);
-    if (!parsedMeal || !parsedMeal.id) {
-      return;
-    }
+    // The rename event carries only paths, and a meal note's body never renders its own
+    // name — so the meal is identified by matching the old filename against the sanitized
+    // name already in JSON, with no need to read or parse the note's content.
+    const oldFilename = oldPath.split('/').pop()?.replace('.md', '') || '';
+    const newFilename = newPath.split('/').pop()?.replace('.md', '') || '';
 
     const meals = await getMeals(ctx);
-    const mealIndex = meals.findIndex(m => m.id === parsedMeal.id);
+    const mealIndex = meals.findIndex(m => FileUtils.sanitizeMealName(m.name) === oldFilename);
 
     if (mealIndex >= 0) {
       const oldMeal = meals[mealIndex];
@@ -386,16 +318,13 @@ export async function handleFileRename(ctx: PluginContext, oldPath: string, newP
         return;
       }
 
-      const updatedMeal = {
+      meals[mealIndex] = {
         ...oldMeal,
         name: newMealName,
         updatedAt: new Date().toISOString()
       };
 
-      meals[mealIndex] = updatedMeal;
       await writeMeals(ctx.vault, ctx.settings, meals);
-
-      await createMealNote(ctx, updatedMeal);
     }
 
   } catch (error) {


### PR DESCRIPTION
## Summary
Makes meal-note sync one-way (JSON → note) and removes the defensive machinery that existed to paper over the old bidirectional architecture's rough edges. ⚠️ Breaking change: hand-editing a meal note no longer syncs back into JSON — this was flagged in the spec as an acceptable, documented 3.0.0 breaking change (a "sync meal from note" explicit command is backlogged for 3.1, not this refactor).

- **`syncMealNoteToJSON` deleted entirely** (note → JSON direction). Its only caller was the `vault.on('modify', ...)` listener, also removed.
- **`handleFileRename` rewritten** to not read or parse the note at all. A meal note's body never renders its own name (only the filename does), so the renamed meal is identified by matching the *old* filename against `sanitizeMealName(name)` in the JSON store — the rename event's two paths are sufficient. Preserves the existing self-trigger guard: when `updateMeal`'s own UI-driven rename fires this listener, the JSON already has the new name, so the old-filename lookup naturally finds no match and no-ops (previously this was an explicit `oldMeal.name === newMealName` check after a JSON-id lookup by parsed content).
- **`main.ts` cleanup**: removed `mealSyncTimeouts` + `setupMealNoteSyncHandler` (the debounced modify-listener), the global `isDeleteInProgress` flag (was blocking *all* deletes app-wide whenever any single delete was in flight — the per-button `data-processing` attribute guard already covers the actual concern, double-clicking the same button), and `ensureModalClosed`'s manual DOM querying/removal (now just tracks `currentModal` and calls `.close()`, which Obsidian's `Modal` class already cleans up after itself).
- **Dead code**: `MealOps.isMealNote` (ctx wrapper) had no callers left once the listener was removed — deleted. `FileUtils.isMealNote` stays; migration (Phase 2d) will likely need it to classify files when scanning a v2 vault.

After this PR, `extractFoodItemsFromContent`/`parseMealFromMarkdown` in `content-parser.ts` have zero production callers (confirmed by grep) — they're left in place rather than deleted-then-recreated, since Phase 2d moves them wholesale into a `legacy/` module for one-time v2→v3 migration.

## Test plan
- [x] `npm run build` passes after every commit
- [x] `npm test` — 9 suites, 85 tests, all passing (5 new: `handleFileRename` hand-rename, self-trigger no-op, out-of-scope-path no-op, orphaned-file no-op, and "no note file touched" cases)
- [x] `grep -rln "extractFoodItemsFromContent\|parseMealFromMarkdown"` (excluding tests) now returns only `content-parser.ts` itself — no callers