### PR TITLE
Fix release workflow: bare semver tags, guard against version drift

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,24 +37,41 @@ jobs:
           npm version ${{ github.event.inputs.version }} --no-git-tag-version
           NEW_VERSION=$(node -p "require('./package.json').version")
           echo "NEW_VERSION=$NEW_VERSION" >> $GITHUB_ENV
-          
+
           # Update manifest.json
           sed -i 's/"version": ".*"/"version": "'$NEW_VERSION'"/' manifest.json
-          
-          # Commit and tag
-          git add package.json manifest.json
-          git commit -m "Bump version to $NEW_VERSION"
-          git tag -a "v$NEW_VERSION" -m "Release v$NEW_VERSION"
-          git push origin HEAD
-          git push origin "v$NEW_VERSION"
 
-      - name: Update manifest version (if tag push)
+          # Update versions.json (plugin version -> minAppVersion)
+          MIN_APP_VERSION=$(node -p "require('./manifest.json').minAppVersion")
+          node -e "
+            const fs = require('fs');
+            const versions = JSON.parse(fs.readFileSync('versions.json', 'utf8'));
+            versions['$NEW_VERSION'] = '$MIN_APP_VERSION';
+            fs.writeFileSync('versions.json', JSON.stringify(versions, null, 2) + '\n');
+          "
+
+          # Commit and tag — bare semver, no "v" prefix, so it matches manifest.json's
+          # version exactly (Obsidian requires the two to match).
+          git add package.json manifest.json versions.json
+          git commit -m "Bump version to $NEW_VERSION"
+          git tag -a "$NEW_VERSION" -m "Release $NEW_VERSION"
+          git push origin HEAD
+          git push origin "$NEW_VERSION"
+
+      - name: Verify tag matches package.json version (if tag push)
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
         run: |
           tag="${GITHUB_REF#refs/tags/}"
+          pkg_version=$(node -p "require('./package.json').version")
+
+          if [ "$tag" != "$pkg_version" ]; then
+            echo "::error::Tag '$tag' does not match package.json version '$pkg_version'. Bump and commit the version (and versions.json) before tagging, or use the workflow_dispatch release instead."
+            exit 1
+          fi
+
           echo "Updating manifest.json version to $tag"
           sed -i 's/"version": ".*"/"version": "'$tag'"/' manifest.json
-          
+
       - name: Build plugin
         run: |
           npm install

--- a/README.md
+++ b/README.md
@@ -109,6 +109,18 @@ Your data lives in your vault, in plain JSON — the rendered notes are a view, 
 - 📊 Visual progress tracking
 - 📁 Automatic file organization
 
+## 📦 Releasing (maintainers)
+
+`release.yml` builds the plugin and publishes a **draft** GitHub release — it's not published as a draft by accident, that's deliberate. Obsidian's community-plugin update mechanism only picks up published releases, so a draft is a safety net: it gives you a chance to sanity-check the build before real users get it.
+
+Before publishing a draft release:
+1. Download the draft's `main.js`, `manifest.json`, and `styles.css`
+2. Drop them into a test vault's `.obsidian/plugins/ai-nutrition-tracker/` folder
+3. Reload Obsidian and run through the core flows for ~5 minutes: log a food entry, edit it, delete it, save a meal, edit a meal item — and if you're testing a vault that has pre-3.0 data, confirm the migration ran cleanly and backups exist under `{log folder}/.data/backup-*.md`
+4. Only then publish the release
+
+To cut a release: either push a bare-semver tag (e.g. `3.0.0`, no `v` prefix — it must match `package.json`'s version exactly, or the workflow fails fast) after bumping the version yourself, or trigger the workflow manually from the Actions tab and let it bump the version for you.
+
 ---
 
 *Transform your nutrition tracking experience - no more tedious logging, just natural descriptions and beautiful results.* 


### PR DESCRIPTION
## Summary
Fixes the two release-workflow bugs the spec called out, plus a third one I found while writing `versions.json` in Phase 3 (repo's `manifest.json`/`package.json` still say `2.0.0` even though `2.0.1` was actually released — the tag-push path never committed its version bump back to `main`).

- **Bare semver everywhere**: `workflow_dispatch` tagged `v$NEW_VERSION` while the release itself used the bare version — two different tags for the same release. Tag-push accepted *any* pushed tag (including the historical `v*` ones) and blindly `sed`'d `manifest.json` to match it, with no validation. Obsidian requires the release tag and `manifest.json`'s version to be identical bare semver, so both paths now agree on that.
- **Tag-push now fails fast on drift** instead of silently building a mismatched release: it compares the pushed tag against `package.json`'s committed version and errors out with a clear message if they don't match. This is the guard that would have caught the `2.0.1` situation instead of shipping it silently.
- **`versions.json` updated in the version-bump step** (workflow_dispatch path) — maps the new version to the current `minAppVersion`.
- **README**: documents why `--draft` stays (Obsidian only picks up published releases, so it's the last manual checkpoint) and the 5-minute smoke-test to run against the draft's built artifacts before publishing.

I couldn't run the actual GitHub Actions job, so I dry-ran the `sed`/`node` logic for both paths against copies of the real `package.json`/`manifest.json`/`versions.json` in `/tmp` to confirm the substitutions and the guard's pass/fail branches actually work — not just that the YAML parses.

## Test plan
- [x] YAML syntax validated (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [x] Dry-ran the workflow_dispatch manifest/versions.json update logic against real file copies — correct output
- [x] Dry-ran the tag-push guard for both a mismatched tag (correctly fails) and a matching tag (correctly proceeds)
- [x] `npm run build` and `npm test` unaffected (92 tests passing) — this PR only touches CI config and README
- [ ] Real end-to-end run happens on the actual next release (can't fully simulate `gh release create` or the git push-back locally)